### PR TITLE
Removal of Caktus/Astro challenge logic.

### DIFF
--- a/frontend/app/factories.js
+++ b/frontend/app/factories.js
@@ -254,16 +254,6 @@ angular.module('TicTacToe.factories', [])
             return {
                 currentPlayer: 1,
                 winner: null,
-                players: {
-                    one: {
-                        name: 'Caktus',
-                        score: 0
-                    },
-                    two: {
-                        name: 'Astro',
-                        score: 0
-                    }
-                },
                 boards: [
                     [{
                         status: 'available',

--- a/frontend/app/templates/gameStats.html
+++ b/frontend/app/templates/gameStats.html
@@ -4,7 +4,6 @@
             <!-- <img src="/static/images/v2-right-col-o.svg" data-ng-show="player==1"/> -->
             <img src="/static/images/v2-right-col-x.svg" />
         </div>
-        <!-- {{ player == 1 ? game.players.one.name: game.players.two.name }} <br> -->
     </div>
     <div data-ng-class="{player: true, inactive: ((game.currentPlayer == 2 && player == 2) || (game.currentPlayer == 1 && player == 1))}">
         <div class="avatar">
@@ -14,6 +13,5 @@
         <div class="cyber-caktus">
           <img src="/static/images/cyber-caktus.svg" />
         </div>
-        <!-- {{ player == 2 ? game.players.one.name: game.players.two.name }}<br> -->
     </div>
 </div>

--- a/tictactoe/t3backend/serializers.py
+++ b/tictactoe/t3backend/serializers.py
@@ -7,7 +7,7 @@ from t3.board import Board
 
 class GameSerializer(serializers.ModelSerializer):
     gametype = serializers.ChoiceField(
-        choices=['local', 'remote', 'ai', 'ai-vs-ai'],
+        choices=['local', 'ai', 'ai-vs-ai'],
         write_only=True
     )
 

--- a/tictactoe/t3backend/urls.py
+++ b/tictactoe/t3backend/urls.py
@@ -8,6 +8,4 @@ urlpatterns = patterns('',
         name='game_list'),
     url(r'^games/(?P<pk>\d+)/$', views.GameDetailAPIView.as_view(),
         name='game_detail'),
-    url(r'^challenges/$', views.ChallengeAPIView.as_view(),
-        name='challenge_list'),
 )

--- a/tictactoe/t3backend/views.py
+++ b/tictactoe/t3backend/views.py
@@ -1,7 +1,6 @@
 from rest_framework import generics, viewsets, mixins
 from django.db.models import Q
 import subprocess
-import random
 import json
 
 from . import models, serializers, tasks
@@ -17,10 +16,6 @@ class GameListAPIView(generics.ListCreateAPIView):
         gametype = serializer.validated_data.pop('gametype')
         if gametype == 'local':
             p1 = p2 = 'local'
-        elif gametype == 'remote':
-            players = ['astro', 'caktus']
-            random.shuffle(players)
-            p1, p2 = players
         elif gametype == 'ai':
             p1, p2 = 'local', 'ai'
         elif gametype == 'ai-vs-ai':
@@ -32,14 +27,6 @@ class GameListAPIView(generics.ListCreateAPIView):
         if p1 == 'ai':
             subprocess.Popen(["python", "tictactoe/t3backend/tasks.py",
                              str(game.pk), state])
-
-
-class ChallengeAPIView(generics.ListAPIView):
-    queryset = models.T3Game.objects.all()
-    serializer_class = serializers.GameSerializer
-
-    def get_queryset(self):
-        return self.queryset.filter(Q(p1='astro') | Q(p1='caktus'), winner=0)
 
 
 class GameDetailAPIView(generics.RetrieveUpdateAPIView):


### PR DESCRIPTION
This removes,
* backend code allowing for challenge games to be created
* the json object containing the player names from the gameState data structure

The Caktus and Astro names in the winner modal have been left in, since there is already a ticket (#45) to address it.

Fixes #25.