### PR TITLE
Record each turn in the database

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ django-appconf==0.6
 six==1.6.1
 git+https://github.com/jbradberry/ultimate_tictactoe#egg=t3
 requests==2.6.0
+pytz==2015.6
 
 BeautifulSoup4==4.3.2
 django-cors-headers==1.0.0

--- a/tictactoe/t3backend/models.py
+++ b/tictactoe/t3backend/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils import timezone
 
 
 class T3Game(models.Model):
@@ -7,3 +8,11 @@ class T3Game(models.Model):
     last_play = models.TextField()
     p1 = models.CharField(max_length=16)
     p2 = models.CharField(max_length=16)
+
+
+class T3Move(models.Model):
+    game = models.ForeignKey(T3Game, related_name='moves')
+    player = models.IntegerField()
+    play = models.TextField()
+    extra = models.TextField(blank=True)
+    timestamp = models.DateTimeField(default=timezone.now)

--- a/tictactoe/t3backend/serializers.py
+++ b/tictactoe/t3backend/serializers.py
@@ -17,12 +17,14 @@ class GameSerializer(serializers.ModelSerializer):
         read_only_fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2')
 
 
-class PlaySerializer(GameSerializer):
+class GameDetailSerializer(GameSerializer):
     play = serializers.CharField(write_only=True)
+    extra = serializers.CharField(allow_blank=True, write_only=True)
 
     class Meta:
         model = models.T3Game
-        fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2', 'play')
+        fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2', 'play',
+                  'extra')
         read_only_fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2')
 
     def validate_play(self, value):

--- a/tictactoe/t3backend/serializers.py
+++ b/tictactoe/t3backend/serializers.py
@@ -17,15 +17,23 @@ class GameSerializer(serializers.ModelSerializer):
         read_only_fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2')
 
 
+class MoveSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.T3Move
+        fields = ('player', 'play', 'extra', 'timestamp')
+
+
 class GameDetailSerializer(GameSerializer):
     play = serializers.CharField(write_only=True)
     extra = serializers.CharField(allow_blank=True, write_only=True)
 
+    moves = MoveSerializer(many=True, read_only=True)
+
     class Meta:
         model = models.T3Game
         fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2', 'play',
-                  'extra')
-        read_only_fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2')
+                  'extra', 'moves')
+        read_only_fields = ('pk', 'state', 'last_play', 'winner', 'p1', 'p2', 'moves')
 
     def validate_play(self, value):
         if self.instance.winner != 0:

--- a/tictactoe/t3backend/tasks.py
+++ b/tictactoe/t3backend/tasks.py
@@ -12,7 +12,7 @@ def ai_play(pk, state):
 
     play = b.pack(ai.get_play())
     url = 'http://localhost:8000/api/games/{pk}/'.format(pk=pk)
-    r = requests.put(url, data={'play': play})
+    r = requests.put(url, data={'play': play, 'extra': json.dumps(ai.stats)})
 
     r.raise_for_status()
 

--- a/tictactoe/t3backend/views.py
+++ b/tictactoe/t3backend/views.py
@@ -58,6 +58,8 @@ class GameDetailAPIView(generics.RetrieveUpdateAPIView):
             # Create a record for the submitted move.
             game.moves.create(player=state[-1], play=play,
                               extra=serializer.validated_data['extra'])
+            # TODO: Change the move submission endpoint to a view that
+            # directly uses MoveSerializer.
 
             game = serializer.save(
                 state=jsonstate, last_play=json.dumps(play),

--- a/tictactoe/t3backend/views.py
+++ b/tictactoe/t3backend/views.py
@@ -31,7 +31,7 @@ class GameListAPIView(generics.ListCreateAPIView):
 
 class GameDetailAPIView(generics.RetrieveUpdateAPIView):
     queryset = models.T3Game.objects.all()
-    serializer_class = serializers.PlaySerializer
+    serializer_class = serializers.GameDetailSerializer
 
     def perform_update(self, serializer):
         state = json.loads(serializer.instance.state)
@@ -54,6 +54,10 @@ class GameDetailAPIView(generics.RetrieveUpdateAPIView):
 
             state = b.play(state, play)
             jsonstate = json.dumps(state)
+
+            # Create a record for the submitted move.
+            game.moves.create(player=state[-1], play=play,
+                              extra=serializer.validated_data['extra'])
 
             game = serializer.save(
                 state=jsonstate, last_play=json.dumps(play),


### PR DESCRIPTION
In analyzing the data obtained from Djangocon 2015, one of my biggest regrets was that we weren't recording the full play-by-play.  If we have this, we can do data analysis on the full sequence of events, allowing us to discover things like whether the AI has particular plays that it likes to make.  We would be able to better debug problems that arise due to particular game situations.  And, we could record the AI's "thoughts" about its move, which is both interesting and currently is seen nowhere except on the console, and is thus lost forever.