### PR TITLE
Use the v0.7.0 tag for the ultimate_tictactoe req

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ django_compressor==1.4
 # Required by django-compressor
 django-appconf==0.6
 six==1.6.1
-git+https://github.com/jbradberry/ultimate_tictactoe#egg=t3
+git+https://github.com/jbradberry/ultimate_tictactoe@v0.7.0#egg=t3
 requests==2.6.0
 pytz==2015.6
 


### PR DESCRIPTION
API changes are happening in the other repo as part of my MCTS unification efforts.  The version tagged 0.7.0 is the last one compatible with the current codebase.