### PR TITLE
Add a default to GameDetailSerializer.extra

### DIFF
--- a/tictactoe/t3backend/serializers.py
+++ b/tictactoe/t3backend/serializers.py
@@ -25,7 +25,7 @@ class MoveSerializer(serializers.ModelSerializer):
 
 class GameDetailSerializer(GameSerializer):
     play = serializers.CharField(write_only=True)
-    extra = serializers.CharField(allow_blank=True, write_only=True)
+    extra = serializers.CharField(allow_blank=True, default='', write_only=True)
 
     moves = MoveSerializer(many=True, read_only=True)
 


### PR DESCRIPTION
Without it, it will show as invalid whenever the extra field is left out.  This was causing the front end to not register moves.